### PR TITLE
Fix analytics flush timer

### DIFF
--- a/lib/flagsmith/sdk/analytics_processor.rb
+++ b/lib/flagsmith/sdk/analytics_processor.rb
@@ -33,7 +33,7 @@ module Flagsmith
 
     def track_feature(feature_name)
       @analytics_data[feature_name] = @analytics_data.fetch(feature_name, 0) + 1
-      flush if (Time.now - @last_flushed) > TIMER * 1000
+      flush if (Time.now - @last_flushed) > TIMER
     end
   end
 end


### PR DESCRIPTION
The analytics flush timer expected the difference between 2 dates to return a value in milliseconds. Actually, it returns seconds. This change ensures that analytics data is flushed every 10 seconds as expected. 