### PR TITLE
fix: Pin the faraday gem file to avoid TypeError superclass mismatch

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     flagsmith (3.2.0)
-      faraday
+      faraday (>= 1.0.0)
       faraday-retry
       faraday_middleware
       semantic

--- a/flagsmith.gemspec
+++ b/flagsmith.gemspec
@@ -6,8 +6,8 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.4.0'
   spec.name = 'flagsmith'
   spec.version = Flagsmith::VERSION
-  spec.authors = ['Tom Stuart', 'Brian Moelk']
-  spec.email = ['tom@solidstategroup.com', 'bmoelk@gmail.com']
+  spec.authors = ['Tom Stuart', 'Brian Moelk', 'Zach Aysan']
+  spec.email = ['tom@solidstategroup.com', 'bmoelk@gmail.com', 'zachaysan@gmail.com']
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
   spec.files = Dir.chdir(__dir__) do
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'rubocop'
 
-  spec.add_dependency 'faraday'
+  spec.add_dependency 'faraday', '>= 1.0.0'
   spec.add_dependency 'faraday_middleware'
   spec.add_dependency 'faraday-retry'
   spec.add_dependency 'semantic'


### PR DESCRIPTION
## Change

Pin the version for the `faraday` gem at the first point where it starts working with our gem. This is roughly four years ago released, so it should be tolerated enough by our clients.

## Testing & Investigation

I did a binary search for when the breaking change stopped. I also looked online to see if this type of breaking change were present in other gems and I found some instances where `faraday` was breaking in the same way, although the steps to remediate it were mixed where some instances were fixed by just reinstalling `faraday` though it wasn't clear that a reinstall was of the same version.

## TODOs
- [ ] Upgrade our version once our CI build works in production and issue a git tag for the version as well.