### PR TITLE
chore: Bump version to 4.0.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    flagsmith (3.2.0)
+    flagsmith (4.0.0)
       faraday (>= 2.0.1)
       faraday-retry
       semantic

--- a/lib/flagsmith/version.rb
+++ b/lib/flagsmith/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Flagsmith
-  VERSION = '3.2.0'
+  VERSION = '4.0.0'
 end


### PR DESCRIPTION
## Changes

Bump the version to 4.0.0 to take into account that we're losing support for pre-3.0 ruby as a dependency upgrade pins it to that. After this PR is merged a new gem must be cut with tags pushed to `main`.

## Testing

A local version of 4.0.0 was cut and tested against a number of known endpoints.