### PR TITLE
fix: Remove dev dependences

### DIFF
--- a/lib/flagsmith.rb
+++ b/lib/flagsmith.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require 'pry'
-require 'pry-byebug'
-
 require 'faraday'
 require 'faraday/retry'
 


### PR DESCRIPTION
## Change

I did the equivalent of leaving my hammer and chisel behind after working on the latest changes to this Ruby gem. This fixes that error by no longer requiring two dev dependencies that I left behind. 

## Testing

Rebuilt the gem locally and installed and tested using a helper file.