### PR TITLE
chore: Bump version to 4.0.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    flagsmith (4.0.0)
+    flagsmith (4.0.1)
       faraday (>= 2.0.1)
       faraday-retry
       semantic

--- a/lib/flagsmith/version.rb
+++ b/lib/flagsmith/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Flagsmith
-  VERSION = '4.0.0'
+  VERSION = '4.0.1'
 end


### PR DESCRIPTION
## Changes

Bump the version to `4.0.1` in order to cut a new gem.

## Testing

Built locally, installed, and tested with local file.