### PR TITLE
feat: Add identity overrides to client

### DIFF
--- a/lib/flagsmith.rb
+++ b/lib/flagsmith.rb
@@ -49,13 +49,14 @@ module Flagsmith
     #
     # You can see full description in the Flagsmith::Config
 
-    attr_reader :config, :environment
+    attr_reader :config, :environment, :identity_overrides_by_identifier
 
     delegate Flagsmith::Config::OPTIONS => :@config
 
     def initialize(config)
       @_mutex = Mutex.new
       @config = Flagsmith::Config.new(config)
+      @identity_overrides_by_identifier = {}
 
       validate_offline_mode!
 
@@ -113,6 +114,16 @@ module Flagsmith
     # You only need to call this if you wish to bypass environment_refresh_interval_seconds.
     def update_environment
       @_mutex.synchronize { @environment = environment_from_api }
+      update_identity_overrides
+    end
+
+    def update_identity_overrides
+      return unless @environment
+
+      @identity_overrides_by_identifier = {}
+      @environment.identity_overrides.each do |identity|
+        @identity_overrides_by_identifier[identity.identifier] = identity
+      end
     end
 
     def environment_from_api
@@ -177,7 +188,7 @@ module Flagsmith
               'Local evaluation or offline handler is required to obtain identity segments.'
       end
 
-      identity_model = build_identity_model(identifier, traits)
+      identity_model = get_identity_model(identifier, traits)
       segment_models = engine.get_identity_segments(environment, identity_model)
       segment_models.map { |sm| Flagsmith::Segments::Segment.new(id: sm.id, name: sm.name) }.compact
     end
@@ -194,7 +205,7 @@ module Flagsmith
     end
 
     def get_identity_flags_from_document(identifier, traits = {})
-      identity_model = build_identity_model(identifier, traits)
+      identity_model = get_identity_model(identifier, traits)
 
       Flagsmith::Flags::Collection.from_feature_state_models(
         engine.get_identity_feature_states(environment, identity_model),
@@ -275,19 +286,28 @@ module Flagsmith
       )
     end
 
-    def build_identity_model(identifier, traits = {})
+    # rubocop:disable Metrics/MethodLength
+    def get_identity_model(identifier, traits = {})
       unless environment
         raise Flagsmith::ClientError,
-              'Unable to build identity model when no local environment present.'
+              'Unable to get identity model when no local environment present.'
       end
 
       trait_models = traits.map do |key, value|
         Flagsmith::Engine::Identities::Trait.new(trait_key: key, trait_value: value)
       end
+
+      if identity_overrides_by_identifier.key? identifier
+        identity = identity_overrides_by_identifier[identifier]
+        identity.update_traits trait_models
+        return identity
+      end
+
       Flagsmith::Engine::Identity.new(
         identity_traits: trait_models, environment_api_key: environment_key, identifier: identifier
       )
     end
+    # rubocop:enable Metrics/MethodLength
 
     def generate_identities_data(identifier, traits = {})
       {

--- a/lib/flagsmith/engine/environments/models.rb
+++ b/lib/flagsmith/engine/environments/models.rb
@@ -6,24 +6,35 @@ module Flagsmith
     class Environment
       attr_reader :id, :api_key
       attr_accessor :project, :feature_states, :amplitude_config, :segment_config,
-                    :mixpanel_config, :heap_config
+                    :mixpanel_config, :heap_config, :identity_overrides
 
-      def initialize(id:, api_key:, project:, feature_states: [])
+      def initialize(id:, api_key:, project:, feature_states: [], identity_overrides: [])
         @id = id
         @api_key = api_key
         @project = project
         @feature_states = feature_states
+        @identity_overrides = identity_overrides
       end
 
       class << self
+        # rubocop:disable Metrics/MethodLength
         def build(json)
           project = Flagsmith::Engine::Project.build(json[:project])
           feature_states = json[:feature_states].map do |fs|
             Flagsmith::Engine::FeatureState.build(fs)
           end
 
-          new(**json.slice(:id, :api_key).merge(project: project, feature_states: feature_states))
+          identity_overrides = json.fetch(:identity_overrides, []).map do |io|
+            Flagsmith::Engine::Identity.build(io)
+          end
+
+          new(**json.slice(:id, :api_key).merge(
+            project: project,
+            feature_states: feature_states,
+            identity_overrides: identity_overrides
+          ))
         end
+        # rubocop:enable Metrics/MethodLength
       end
     end
 

--- a/spec/sdk/fixtures/environment.json
+++ b/spec/sdk/fixtures/environment.json
@@ -66,5 +66,31 @@
       "segment_id": null,
       "enabled": true
     }
+  ],
+  "updated_at": "2023-07-14 16:12:00.000000",
+  "identity_overrides": [
+    {
+      "identifier": "overridden-id",
+      "identity_uuid": "0f21cde8-63c5-4e50-baca-87897fa6cd01",
+      "created_date": "2019-08-27T14:53:45.698555Z",
+      "updated_at": "2023-07-14 16:12:00.000000",
+      "environment_api_key": "B62qaMZNwfiqT76p38ggrQ",
+      "identity_features": [
+        {
+          "id": 1,
+          "feature": {
+            "id": 1,
+            "name": "some_feature",
+            "type": "STANDARD"
+          },
+          "featurestate_uuid": "1bddb9a5-7e59-42c6-9be9-625fa369749f",
+          "feature_state_value": "some-overridden-value",
+          "enabled": false,
+          "environment": 1,
+          "identity": null,
+          "feature_segment": null
+        }
+      ]
+    }
   ]
 }

--- a/spec/sdk/local_evaluation_spec.rb
+++ b/spec/sdk/local_evaluation_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+require_relative 'shared_mocks.rb'
+
+RSpec.describe Flagsmith do
+  include_context 'shared mocks'
+
+  describe '#get_identity_overrides_flags' do
+    it 'should return identity overrides in local evaluation' do
+      allow_any_instance_of(Flagsmith::Client).to receive(:api_client).and_return(mock_api_client)
+
+      flagsmith = Flagsmith::Client.new(environment_key: mock_api_key, api_url: mock_api_url, enable_local_evaluation: true)
+      expect(flagsmith.config.local_evaluation?).to be_truthy
+
+      flag = flagsmith.get_identity_flags("overridden-id").get_flag("some_feature")
+
+      expect(flag.enabled).to be_falsy
+      expect(flag.value).to eq("some-overridden-value")
+    end
+  end
+end


### PR DESCRIPTION
## Changes

Fixes https://github.com/Flagsmith/flagsmith-ruby-client/issues/42

This change introduces identity overrides to the ruby Flagsmith client. The identity overrides are placed on to the environment model and as an optimization for lookup an identity identifier keyed hash lookup was also added to the client as requested by the linked issue.

## Testing

Created a new spec file for local evaluation as there were none present in the repo initially. The spec has to work around some limitations of the local evaluation boot cycle so the shared mocks were only partially used since we need to mock the class, not just an instance, which on boot pulls an initial request from the API.