### PR TITLE
fix: Make local evaluation multivariate work

### DIFF
--- a/lib/flagsmith.rb
+++ b/lib/flagsmith.rb
@@ -198,6 +198,7 @@ module Flagsmith
 
       Flagsmith::Flags::Collection.from_feature_state_models(
         engine.get_identity_feature_states(environment, identity_model),
+        identity_id: identity_model.composite_key,
         analytics_processor: analytics_processor,
         default_flag_handler: default_flag_handler,
         offline_handler: offline_handler

--- a/spec/sdk/fixtures/environment.json
+++ b/spec/sdk/fixtures/environment.json
@@ -65,6 +65,29 @@
       },
       "segment_id": null,
       "enabled": true
+    },
+    {
+      "feature": {
+        "id": 83755,
+        "name": "test_mv",
+        "type": "MULTIVARIATE"
+      },
+      "enabled": false,
+      "django_id": 482285,
+      "feature_segment": null,
+      "featurestate_uuid": "c3af5fbf-39ba-422c-a846-f2fea952b37c",
+      "feature_state_value": "1111",
+      "multivariate_feature_state_values": [
+        {
+          "multivariate_feature_option": {
+            "value": "8888",
+            "id": 11516
+          },
+          "percentage_allocation": 100.0,
+          "id": 38451,
+          "mv_fs_value_uuid": "a4299c73-2430-47e4-9185-42accd01686c"
+        }
+      ]
     }
   ]
 }

--- a/spec/sdk/local_evaluation_spec.rb
+++ b/spec/sdk/local_evaluation_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+require_relative 'shared_mocks.rb'
+
+RSpec.describe Flagsmith do
+  include_context 'shared mocks'
+
+  describe '#get_multivariate_flags' do
+    it 'should return a 100% multivariate variation in local evaluation' do
+      allow_any_instance_of(Flagsmith::Client).to receive(:api_client).and_return(mock_api_client)
+
+      flagsmith = Flagsmith::Client.new(environment_key: mock_api_key, api_url: mock_api_url, enable_local_evaluation: true)
+      expect(flagsmith.config.local_evaluation?).to be_truthy
+
+      flag = flagsmith.get_identity_flags("some-identifier").get_flag("test_mv")
+
+      expect(flag.enabled).to be_falsy
+      expect(flag.value).to eq("8888")
+    end
+  end
+end

--- a/spec/sdk/offline_mode_spec.rb
+++ b/spec/sdk/offline_mode_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Flagsmith::Client do
     )
 
     response = flagsmith.get_environment_flags
-    expect(response.count).to eq(1)
+    expect(response.count).to eq(2)
     expect(response.first[-1].feature_name).to eq("some_feature")
   end
 


### PR DESCRIPTION
## Changes

Fixes https://github.com/Flagsmith/flagsmith-ruby-client/issues/49

In order to get multivariate responses to work properly a missing `identity_id` for the method `from_feature_state_models` was set to a synthetic id called `identity_model.composite_key`. This was based off of the same type of logic that's present in the Python client.

## Testing

Tested locally with the changes against a multivariate feature that exists in production and was able to confirm switching the logic based off of the percent allocation. 

In addition, a test was created with a new addition to the existing fixture for the `environment.json` payload.