### PR TITLE
fix: Mute analytics processor on failure

### DIFF
--- a/lib/flagsmith.rb
+++ b/lib/flagsmith.rb
@@ -92,7 +92,8 @@ module Flagsmith
       @analytics_processor ||=
         Flagsmith::AnalyticsProcessor.new(
           api_client: api_client,
-          timeout: request_timeout_seconds
+          timeout: request_timeout_seconds,
+          logger: @config.logger,
         )
     end
 

--- a/lib/flagsmith.rb
+++ b/lib/flagsmith.rb
@@ -93,7 +93,7 @@ module Flagsmith
         Flagsmith::AnalyticsProcessor.new(
           api_client: api_client,
           timeout: request_timeout_seconds,
-          logger: @config.logger,
+          logger: @config.logger
         )
     end
 

--- a/lib/flagsmith/sdk/analytics_processor.rb
+++ b/lib/flagsmith/sdk/analytics_processor.rb
@@ -19,15 +19,20 @@ module Flagsmith
       @analytics_data = {}
       @api_client = data.fetch(:api_client)
       @timeout = data.fetch(:timeout, 3)
+      @logger = data.fetch(:logger)
     end
 
     # Sends all the collected data to the api asynchronously and resets the timer
     def flush
       return if @analytics_data.empty?
 
-      @api_client.post(ENDPOINT, @analytics_data.to_json)
+      begin
+        @api_client.post(ENDPOINT, @analytics_data.to_json)
+        @analytics_data = {}
+      rescue StandardError => e
+        @logger.warn "Temporarily unable to access flag analytics endpoint for exception: #{e}"
+      end
 
-      @analytics_data = {}
       @last_flushed = Time.now
     end
 

--- a/spec/sdk/analytics_processor_spec.rb
+++ b/spec/sdk/analytics_processor_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Flagsmith::AnalyticsProcessor do
   end
 
   subject do Flagsmith::AnalyticsProcessor.new(
-    api_client: flagsmith.api_client, timeout: flagsmith.config.request_timeout_seconds
+    api_client: flagsmith.api_client, timeout: flagsmith.config.request_timeout_seconds, logger: flagsmith.config.logger
     )
   end
 


### PR DESCRIPTION
## Changes

Fixes https://github.com/Flagsmith/flagsmith-ruby-client/issues/53

Since the analytics processor can fail, but since failure isn't traumatic, a guard clause is added to side step the failures to ensure the rest of the application functions normally.

## Testing

Worked with it locally to sort of tease out different cases against the code.