### PR TITLE
fix: Stop repeated calls to update environment when polling manager is set

### DIFF
--- a/lib/flagsmith.rb
+++ b/lib/flagsmith.rb
@@ -104,7 +104,7 @@ module Flagsmith
     def environment_data_polling_manager
       return nil unless @config.local_evaluation?
 
-      update_environment
+      update_environment if @environment_data_polling_manager.nil?
 
       @environment_data_polling_manager ||= Flagsmith::EnvironmentDataPollingManager.new(
         self, environment_refresh_interval_seconds


### PR DESCRIPTION
## Change

Fixes https://github.com/Flagsmith/flagsmith-ruby-client/issues/56

Removing the `update_environment` check on every evocation of the `environment_data_polling_manager` method. Since `environment_data_polling_manager` calls the `update_environment` method *anyway* there is no real use in forcing an update except during the initial load.

## Testing

Local testing with `enable_local_evaluation: true` set for the client and waiting out the timeouts for the updating to trigger.