### PR TITLE
feat: Support transient identities and traits

### DIFF
--- a/spec/sdk/fixtures/identities.json
+++ b/spec/sdk/fixtures/identities.json
@@ -59,12 +59,14 @@
     {
       "id": 215352,
       "trait_key": "roles",
-      "trait_value": "[\"admin\",\"staff\"]"
+      "trait_value": "[\"admin\",\"staff\"]",
+      "transient": false
     },
     {
       "id": 215988,
       "trait_key": "foo",
-      "trait_value": "bar"
+      "trait_value": "bar",
+      "transient": false
     }
   ]
 }

--- a/spec/sdk/flagsmith_spec.rb
+++ b/spec/sdk/flagsmith_spec.rb
@@ -62,39 +62,6 @@ RSpec.describe Flagsmith do
     end
   end
 
-  # describe '#set_trait' do
-  #   let(:trait_key) { 'foo' }
-  #   let(:trait_value) { 'bar' }
-  #   let(:post_body) do
-  #     {
-  #       identity: { identifier: user_id },
-  #       trait_key: Flagsmith::Flags::Collection.normalize_key(trait_key),
-  #       trait_value: trait_value
-  #     }.to_json
-  #   end
-  #
-  #   it 'sets a trait for a given user' do
-  #     trait_response = OpenStruct.new(body: {})
-  #     expect(mock_api_client).to receive(:post).with('traits/', post_body).and_return(trait_response)
-  #     subject.set_trait user_id, trait_key, trait_value
-  #   end
-  #
-  #   it 'errors if user_id.nil?' do
-  #     expect { subject.set_trait nil, trait_key, trait_value }.to raise_error(StandardError)
-  #   end
-  # end
-
-  # describe '#get_traits' do
-  #   it 'returns hash of traits for a given user' do
-  #     traits = subject.get_traits(user_id)
-  #     expect(traits['roles']).to eq(%w[admin staff].to_json)
-  #     expect(traits.length).to eq(2)
-  #   end
-  #   it 'returns {} for user_id.nil?' do
-  #     expect(subject.get_traits(nil)).to eq({})
-  #   end
-  # end
-
   describe '#normalize_key' do
     it 'returns an empty string given nil' do
       expect(Flagsmith::Flags::Collection.normalize_key(nil)).to eq('')
@@ -120,6 +87,43 @@ RSpec.describe Flagsmith do
       polling_manager = Flagsmith::EnvironmentDataPollingManager.new(subject, 60, 10)
       subject.update_environment()
       expect(subject.get_identity_segments("identifier", {"age": 39}).length).to eq(1)
+    end
+  end
+
+  describe '#get_identity_flags' do
+    context 'with transient identity' do
+      before {
+        transient_identities_response = OpenStruct.new(body: { **identities_response.body } )
+        transient_identities_response.body[:traits] = identities_response.body[:traits].map{ |api_trait| { **api_trait, transient: true } }
+        allow(mock_api_client).to receive(:post).with(
+          'identities/', { identifier: user_id, transient: true, traits: [] }.to_json
+        ).and_return(transient_identities_response)    
+      }
+
+      it 'sends expected request' do
+        flags = subject.get_identity_flags(user_id, true)
+        expect(flags.feature_enabled?(:feature_one)).to eq(false)
+        expect(flags.feature_enabled?('feature_two')).to eq(true)
+        expect(flags.feature_enabled?(:feature_three)).to eq(true)
+      end
+    end
+
+    context 'with transient trait' do 
+      before {
+        transient_trait_data = { trait_key: "age", trait_value: 42, transient: true }
+        transient_traits_response = OpenStruct.new(body: { **identities_response.body } )
+        transient_traits_response.body[:traits] = transient_traits_response.body[:traits] + [transient_trait_data]
+        allow(mock_api_client).to receive(:post).with(
+          'identities/', { identifier: user_id, transient: false, traits: [transient_trait_data] }.to_json
+        ).and_return(transient_traits_response)    
+      }
+
+      it 'sends expected request' do
+        flags = subject.get_identity_flags(user_id, age: { value: 42, transient: true })
+        expect(flags.feature_enabled?(:feature_one)).to eq(false)
+        expect(flags.feature_enabled?('feature_two')).to eq(true)
+        expect(flags.feature_enabled?(:feature_three)).to eq(true)
+      end
     end
   end
 end

--- a/spec/sdk/shared_mocks.rb
+++ b/spec/sdk/shared_mocks.rb
@@ -30,7 +30,7 @@ RSpec.shared_context 'shared mocks', shared_context: :metadata do
                                            .and_return(mock_api_client)
     allow(mock_api_client).to receive(:get).with('flags/').and_return(flags_response)
     allow(mock_api_client).to receive(:post).with(
-      'identities/', { identifier: user_id, traits: [] }.to_json
+      'identities/', { identifier: user_id, transient: false, traits: [] }.to_json
     ).and_return(identities_response)
     allow(mock_api_client).to receive(:get).with('environment-document/')
                                            .and_return(environment_document_response)


### PR DESCRIPTION
Closes #63.

- Add optional `transient` argument to `get_identity_flags`
- Add support for trait configuration values with optional `transient` key
- Remove unneeded default argument values from private methods
- Remove unneeded comments from the spec

Notes:

1. I've added a `rubocop:disable Style/OptionalBooleanParameter` exclusion for the new argument to `get_identity_flags`. This is to avoid conflict in case a user intends to send a trait called `transient`.
2. I've removed commented out specs for `set_trait`/`get_traits` interfaces that have not been implemented. I don't like having commented out code in general, and those methods are not expected to be there in a server-side SDK anyway.
3. I've removed the default `traits = {}` from internal methods as they are not needed — the empty hash is always provided by the top `get_identity_flags` interface — but also because Rubocop complained about having non-optional `transient` argument after `traits`, and I did not want to change the argument order anywhere, or litter the default value for `transient` throughout the stack.