### PR TITLE
fix: allow false as a flag value

### DIFF
--- a/lib/flagsmith/sdk/models/flags.rb
+++ b/lib/flagsmith/sdk/models/flags.rb
@@ -71,7 +71,7 @@ module Flagsmith
         def from_api(json_flag_data)
           new(
             enabled: json_flag_data[:enabled],
-            value: json_flag_data[:feature_state_value] || json_flag_data[:value],
+            value: json_flag_data.fetch(:feature_state_value) { json_flag_data[:value] },
             feature_name: json_flag_data.dig(:feature, :name),
             feature_id: json_flag_data.dig(:feature, :id)
           )


### PR DESCRIPTION
This commit updates `Flagsmith::Flags::Flag#from_api` to support `false` as a valid value.

Previously, `false` values for `:feature_state_value` would would fall through the `||` branch and end up using the value from `:value`, which in most (all?) cases seems to be `nil`.

The previous behavior made it impossible to distinguish between the following two cases:

- an enabled flag that has never had its value set (and should therefore be treated as `true`)

- an enabled flag that is explicitly set to `false` (and should therefore be treated as `false`)

With the change in this commit, the first case will be `nil`, and the second case would be `false`. The `:value` key will now only be consulted when there is no `:feature_state_value` key present in the JSON flag data.