### PR TITLE
chore: Bump to 4.3.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    flagsmith (4.2.0)
+    flagsmith (4.3.0)
       faraday (>= 2.0.1)
       faraday-retry
       semantic

--- a/lib/flagsmith/version.rb
+++ b/lib/flagsmith/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Flagsmith
-  VERSION = '4.2.0'
+  VERSION = '4.3.0'
 end


### PR DESCRIPTION
Bumping the version before tagging the release and updating rubygems.