### PR TITLE
feat: added-version-in-user-agent-header

### DIFF
--- a/lib/flagsmith.rb
+++ b/lib/flagsmith.rb
@@ -7,11 +7,14 @@ require 'faraday/retry'
 # This is the patch to use slice in earler versions
 require 'flagsmith/hash_slice'
 
+require 'flagsmith/version'
+
 require 'flagsmith/sdk/analytics_processor'
 require 'flagsmith/sdk/api_client'
 require 'flagsmith/sdk/config'
 require 'flagsmith/sdk/errors'
 require 'flagsmith/sdk/intervals'
+require 'flagsmith/sdk/utils'
 require 'flagsmith/sdk/pooling_manager'
 require 'flagsmith/sdk/models/flags'
 require 'flagsmith/sdk/models/segments'

--- a/lib/flagsmith/sdk/api_client.rb
+++ b/lib/flagsmith/sdk/api_client.rb
@@ -31,6 +31,7 @@ module Flagsmith
       faraday.headers['Accept'] = 'application/json'
       faraday.headers['Content-Type'] = 'application/json'
       faraday.headers['X-Environment-Key'] = config.environment_key
+      faraday.headers['User-Agent'] = Flagsmith::SDK::Utils.user_agent
       faraday.headers.merge(config.custom_headers)
     end
 

--- a/lib/flagsmith/sdk/utils.rb
+++ b/lib/flagsmith/sdk/utils.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Flagsmith
+  module SDK
+    # Utility functions
+    module Utils
+      FLAGSMITH_USER_AGENT = 'flagsmith-ruby-sdk'
+      FLAGSMITH_UNKNOWN_VERSION = 'unknown'
+
+      module_function
+
+      # Returns the user agent string for HTTP requests
+      # @return [String] user agent in format "flagsmith-ruby-sdk/version"
+      def user_agent
+        "#{FLAGSMITH_USER_AGENT}/#{version}"
+      end
+
+      # Returns the SDK version
+      # @return [String] version string or 'unknown' if not available
+      def version
+        return Flagsmith::VERSION if defined?(Flagsmith::VERSION)
+
+        FLAGSMITH_UNKNOWN_VERSION
+      rescue StandardError
+        FLAGSMITH_UNKNOWN_VERSION
+      end
+    end
+  end
+end

--- a/spec/sdk/api_client_spec.rb
+++ b/spec/sdk/api_client_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Flagsmith::ApiClient do
+  let(:config) do
+    Flagsmith::Config.new(
+      environment_key: 'test-key',
+      api_url: 'https://edge.api.flagsmith.com/api/v1/'
+    )
+  end
+
+  describe 'headers' do
+    it 'sets User-Agent header with SDK version' do
+      api_client = described_class.new(config)
+      connection = api_client.instance_variable_get(:@conn)
+
+      expected_user_agent = "flagsmith-ruby-sdk/#{Flagsmith::VERSION}"
+      expect(connection.headers['User-Agent']).to eq(expected_user_agent)
+    end
+  end
+end

--- a/spec/sdk/utils_spec.rb
+++ b/spec/sdk/utils_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Flagsmith::SDK::Utils do
+  describe '.user_agent' do
+    it 'returns user agent with version' do
+      expected_user_agent = "flagsmith-ruby-sdk/#{Flagsmith::VERSION}"
+      expect(described_class.user_agent).to eq(expected_user_agent)
+    end
+
+    it 'includes the correct format' do
+      user_agent = described_class.user_agent
+      expect(user_agent).to match(/^flagsmith-ruby-sdk\/\d+\.\d+\.\d+$/)
+    end
+  end
+
+  describe '.version' do
+    it 'returns the Flagsmith version' do
+      expect(described_class.version).to eq(Flagsmith::VERSION)
+    end
+
+    it 'returns a non-empty string' do
+      expect(described_class.version).to be_a(String)
+      expect(described_class.version).not_to be_empty
+    end
+
+    context 'when VERSION constant is not available' do
+      it 'returns unknown as fallback' do
+        version_backup = Flagsmith::VERSION
+        Flagsmith.send(:remove_const, :VERSION)
+
+        expect(described_class.version).to eq('unknown')
+
+        Flagsmith.const_set(:VERSION, version_backup)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Thanks for submitting a PR! Please check the boxes below:

- [ ] I have added information to `docs/` if required so people know about the feature!
- [x] I have filled in the "Changes" section below?
- [x] I have filled in the "How did you test this code" section below?
- [x] I have used a [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) title for this Pull Request

## Changes
-  new utility `getUserAgent` to get version from composer as `flagsmith-ruby-sdk/v4.3.0` or returns `flagsmith-php-sdk/unknown` (not realistic as the version is required in Gem)
- Added header in API and Analytics requests

## How did you test this code?
- Added tests
- used Dummy script and got the desired 
```
Headers configured in Faraday connection:
  Accept: application/json
  Content-Type: application/json
  X-Environment-Key: test-key
  User-Agent: flagsmith-ruby-sdk/4.3.0
```