### PR TITLE
fix: respect rule type for sub-rules in segment evaluation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "spec/engine-test-data"]
 	path = spec/engine-test-data
 	url = git@github.com:Flagsmith/engine-test-data.git
-	branch = v3.5.0
+	branch = v3.7.0

--- a/lib/flagsmith/engine/segments/evaluator.rb
+++ b/lib/flagsmith/engine/segments/evaluator.rb
@@ -93,7 +93,7 @@ module Flagsmith
             end
 
           matches_conditions &&
-            rule.rules.all? { |r| traits_match_segment_rule(identity_traits, r, segment_id, identity_id) }
+            rule.rules.send(rule.matching_function) { |r| traits_match_segment_rule(identity_traits, r, segment_id, identity_id) }
         end
         # rubocop:enable Metrics/MethodLength
 
@@ -137,9 +137,10 @@ module Flagsmith
         def evaluate_sub_rules_from_context(rule, segment_key, context)
           return true if rule[:rules].nil? || rule[:rules].empty?
 
-          rule[:rules].all? do |sub_rule|
+          sub_rule_results = rule[:rules].map do |sub_rule|
             traits_match_segment_rule_from_context(sub_rule, segment_key, context)
           end
+          evaluate_rule_conditions(rule[:type], sub_rule_results)
         end
 
         # Evaluates a single segment condition using context


### PR DESCRIPTION
## Summary
- Bumped engine-test-data submodule from v3.5.0 to v3.7.0
- Fixed segment evaluation: sub-rules now respect the parent rule's type (ANY/ALL/NONE) instead of hardcoding ALL

Equivalent fix to [flagsmith-engine#313](https://github.com/Flagsmith/flagsmith-engine/pull/313).

## Test plan
- [x] Bumped engine-test-data to v3.7.0 (includes 3 new sub-rule type test cases)
- [x] Verified tests fail before the fix
- [x] Applied the fix
- [x] Verified all tests pass after the fix